### PR TITLE
Getting handling JSON.parse() errors from `node-fetch` gracefully

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 4.3.2
+    version: 6.5.0
 
 deployment:
   release:

--- a/fetch.js
+++ b/fetch.js
@@ -6,7 +6,17 @@ module.exports = (input, init) => {
 	return fetch(input, init)
 		.then(response => {
 			if (response.ok) {
-				return response.json();
+				let contentType;
+				try {
+					contentType = response.headers.get('content-type');
+				}
+				catch (error) {
+					logger.warn(error);
+				}
+
+				return contentType && contentType.includes('json')
+					? response.json()
+					: response.text();
 			} else {
 				logger.warn({
 					event: 'N_FETCH_ERROR',
@@ -19,5 +29,8 @@ module.exports = (input, init) => {
 						throw httpError(response.status, text);
 					});
 			}
+		})
+		.catch(error => {
+			throw error;
 		});
 };

--- a/n.Makefile
+++ b/n.Makefile
@@ -30,11 +30,12 @@ NPM_INSTALL = npm prune --production=false && npm install
 BOWER_INSTALL = bower prune && bower install --config.registry.search=http://registry.origami.ft.com --config.registry.search=https://bower.herokuapp.com
 JSON_GET_VALUE = grep $1 | head -n 1 | sed 's/[," ]//g' | cut -d : -f 2
 IS_GIT_IGNORED = grep -q $(if $1, $1, $@) .gitignore
-VERSION = v15
+VERSION = v31
 APP_NAME = $(shell cat package.json 2>/dev/null | $(call JSON_GET_VALUE,name))
 DONE = echo ✓ $@ done
 CONFIG_VARS = curl -fsL https://ft-next-config-vars.herokuapp.com/$1/$(call APP_NAME)$(if $2,.$2,) -H "Authorization: `heroku config:get APIKEY --app ft-next-config-vars`"
-
+IS_USER_FACING = `find . -type d \( -path ./bower_components -o -path ./node_modules \) -prune -o -name '*.html' -print`
+MAKEFILE_HAS_A11Y = `grep -rli "make a11y\|a11y:" Makefile`
 
 #
 # META TASKS
@@ -95,7 +96,7 @@ ifneq ($(CIRCLE_BUILD_NUM),)
 ifneq ($(shell grep -s -Fim 1 n-ui bower.json),)
 # versions in package.json and bower.json are not equal
 ifneq ($(shell awk '$$1 == "\"version\":" {print $$2}' bower_components/n-ui/.bower.json | sed s/,//),$(shell awk '$$1 == "\"version\":" {print $$2}'  node_modules/@financial-times/n-ui/package.json | sed s/,//))
-	$(error 'Projects using n-ui must maintain parity between versions. Rebuild without cache and update your bower.json and package.json if necessary')
+	$(error 'Projects using n-ui must maintain parity between versions. Rebuild without cache and update your bower.json and package.json if necessary. If this error persists make sure that the n-ui build succeeded in publishing a new version to NPM and that both NPM and Bower registries have the latest version.')
 endif
 endif
 endif
@@ -152,6 +153,23 @@ ENV_MSG_CANT_GET = "Error: Cannot get config vars for this service. Check you ar
 	@if [ ! -z $(CIRCLECI) ]; then (echo $(ENV_MSG_CIRCLECI) && exit 1); fi
 	@$(call CONFIG_VARS,development,env) > .env && perl -pi -e 's/="(.*)"/=\1/' .env && $(DONE) || (echo $(ENV_MSG_CANT_GET) && rm .env && exit 1);
 
+# replace .env with this .env2 when you want to use the vault instead of config-vars
+.env-vault:
+	@if [[ $(shell grep --count *.env* .gitignore) -eq 0 ]]; then (echo $(ENV_MSG_IGNORE_ENV) && exit 1); fi
+	@if [ ! -e package.json ]; then (echo $(ENV_MSG_PACKAGE_JSON) && exit 1); fi
+	@if [ ! -z $(CIRCLECI) ]; then (echo $(ENV_MSG_CIRCLECI) && exit 1); fi
+# get development config from the vault
+# - the tail command removes the first three lines (vault metadata)
+# - the 1st sed command removes the last line (empty line)
+# - the 2nd sed command changes remaining lines to key=value format
+	@vault auth --method github \
+		&& vault read secret/teams/next/$(APP_NAME)/development \
+		| tail -n +4 \
+		| sed -e '$$ d' \
+		| sed -E 's/^([^ ]*)[[:blank:]]*([^ ].*)$$/\1=\2/' \
+		> .env
+	@$(DONE)
+
 MSG_HEROKU_CLI = "Please make sure the Heroku CLI toolbelt is installed - see https://toolbelt.heroku.com/. And make sure you are authenticated by running ‘heroku login’. If this is not an app, delete Procfile."
 heroku-cli:
 	@if [ -e Procfile ]; then heroku auth:whoami &>/dev/null || (echo $(MSG_HEROKU_CLI) && exit 1); fi
@@ -169,9 +187,12 @@ _verify_scss_lint:
 	@if [ -e .scss-lint.yml ]; then { scss-lint -c ./.scss-lint.yml `$(call GLOB,'*.scss')`; if [ $$? -ne 0 -a $$? -ne 1 ]; then exit 1; fi; $(DONE); } fi
 
 VERIFY_MSG_NO_DEMO = "Error: Components with templates must have a demo app, so that pa11y can test against it. This component doesn’t seem to have one. Add a demo app to continue peacefully. See n-image for an example."
-
+VERIFY_MSG_NO_PA11Y = "\n**** Error ****\nIt looks like your code is user-facing; your Makefile should include make a11y\nIf you need to disable a11y, use export IGNORE_A11Y = true in your Makefile\n********\n\n"
+#check if project has HTML and missing make a11y command
+#check if project has demo app if there's a make a11y command
 _verify_pa11y_testable:
-	@if [ ! -d server ] && [ -d templates ] && [ ! -f demos/app.js ]; then (echo $(VERIFY_MSG_NO_DEMO) && exit 1); fi
+	@if [ ! -z "$(IS_USER_FACING)" ] && [ -z $(MAKEFILE_HAS_A11Y) ] && [ ! ${IGNORE_A11Y} ]; then (printf $(VERIFY_MSG_NO_PA11Y) && exit 1); fi
+	@if [ ! -z "$(IS_USER_FACING)" ] && [ ! -d server ] && [ ! -f demos/app.js ]; then (echo $(VERIFY_MSG_NO_DEMO) && exit 1); fi
 	@$(DONE)
 
 _run_pa11y:
@@ -217,6 +238,7 @@ hel%: ## help: Show this help message.
 	@grep -Eh '^.+:\ ##\ .+' ${MAKEFILE_LIST} | cut -d ' ' -f '3-' | column -t -s ':'
 
 # Wrapper for make deploy which prevents it running when build is a nightly
+# Nightly builds are trigger by next-rebuild-bot
 deploy-by-day:
 ifeq ($(FT_NIGHTLY_BUILD),)
 	$(MAKE) deploy

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint": "^3.19.0",
     "lintspaces-cli": "^0.6.0",
     "mocha": "^3.2.0",
+    "nock": "^9.0.13",
     "npm-prepublish": "^1.2.2",
     "pre-git": "^3.14.0",
     "proxyquire": "^1.7.11",

--- a/test/fetch.spec.js
+++ b/test/fetch.spec.js
@@ -17,7 +17,13 @@ describe('fetch', () => {
 		stub.logger.warn = sinon.stub();
 	});
 	it('fetches', () => {
-		stub.fetch.withArgs('https://www.teddy.com/status').returns(Promise.resolve({ ok: true, json: () => Promise.resolve({ foo: 'bar' }) }));
+		stub.fetch.withArgs('https://www.teddy.com/status').returns(Promise.resolve({
+			ok: true,
+			headers: {
+				get: () => 'application/json'
+			},
+			json: () => Promise.resolve({ foo: 'bar' })
+		}));
 		return fetch('https://www.teddy.com/status').then(data => {
 			expect(data).to.deep.equal({ foo: 'bar' });
 		});

--- a/test/node-fetch.spec.js
+++ b/test/node-fetch.spec.js
@@ -4,7 +4,7 @@ const nock = require('nock');
 const proxyquire = require('proxyquire');
 const fetch = proxyquire('../fetch', {'@financial-times/n-logger': {}});
 
-const fakedotcom = nock('http://www.fake.com')
+nock('http://www.fake.com')
 	.get('/text')
 	.reply(200, 'some text')
 	.get('/json')

--- a/test/node-fetch.spec.js
+++ b/test/node-fetch.spec.js
@@ -1,0 +1,26 @@
+const chai = require('chai');
+const expect = chai.expect;
+const nock = require('nock');
+const proxyquire = require('proxyquire');
+const fetch = proxyquire('../fetch', {'@financial-times/n-logger': {}});
+
+const fakedotcom = nock('http://www.fake.com')
+	.get('/text')
+	.reply(200, 'some text')
+	.get('/json')
+	.reply(200, {'some':'json'});
+
+describe('node-fetch', () => {
+	it('handles json responses', () => {
+		return fetch('http://www.fake.com/json')
+			.then(response => {
+				expect(response).to.deep.equal({'some':'json'});
+			});
+	});
+	it('handles text responses', () => {
+		return fetch('http://www.fake.com/text')
+			.then(response => {
+				expect(response).to.equal('some text');
+			});
+	});
+});

--- a/test/node-fetch.spec.js
+++ b/test/node-fetch.spec.js
@@ -8,7 +8,10 @@ const fakedotcom = nock('http://www.fake.com')
 	.get('/text')
 	.reply(200, 'some text')
 	.get('/json')
-	.reply(200, {'some':'json'});
+	.reply(200,
+		{'some':'json'},
+		{'Content-Type': 'application/json'}
+	);
 
 describe('node-fetch', () => {
 	it('handles json responses', () => {


### PR DESCRIPTION
If you fetch() something that does not return a json response, it throws a syntax error when calling `response.json();` here:

![image](https://cloud.githubusercontent.com/assets/224547/26408157/f6192314-4094-11e7-8557-9b07b943c71e.png)

This PR contains:
 * a couple of unit tests to reproduce the error, and 
 * an attempt at having it fail gracefully by returning `response.text()` if the response's "content-type" doesn't include "json".