### PR TITLE
Require n-logger v10.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "@financial-times/n-logger": "^8.0.0",
+        "@financial-times/n-logger": "^10.2.0",
         "http-errors": "^1.6.1",
         "node-fetch": "^2.0.0"
       },
@@ -28,7 +28,7 @@
         "snyk": "^1.167.2"
       },
       "engines": {
-        "node": "12.x",
+        "node": "14.x || 16.x",
         "npm": "7.x || 8.x"
       }
     },
@@ -1759,16 +1759,18 @@
       }
     },
     "node_modules/@financial-times/n-logger": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-8.0.1.tgz",
-      "integrity": "sha512-Ezy1Xg9MHr6rgQf0AuYMcv/idRvAZ9ba7UYR7qov2rAtjMXPl6daS89J+j+uTCedIYVUcvC+Plitme17zARJYg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
+      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
+      "hasInstallScript": true,
       "dependencies": {
         "json-stringify-safe": "^5.0.1",
         "node-fetch": "^2.6.0",
         "winston": "^2.4.0"
       },
       "engines": {
-        "node": "12.x"
+        "node": "14.x || 16.x",
+        "npm": "7.x || 8.x"
       }
     },
     "node_modules/@financial-times/n-pa11y-config": {
@@ -15717,9 +15719,9 @@
       }
     },
     "@financial-times/n-logger": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-8.0.1.tgz",
-      "integrity": "sha512-Ezy1Xg9MHr6rgQf0AuYMcv/idRvAZ9ba7UYR7qov2rAtjMXPl6daS89J+j+uTCedIYVUcvC+Plitme17zARJYg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/n-logger/-/n-logger-10.2.0.tgz",
+      "integrity": "sha512-7mjjYNSMklnTky+WLhFqdFvT6VBM+QOHkMnfoclqv0YoJlatY/oP8MtfeufxXqGBzGJrRH90xbq0Qs1InracXQ==",
       "requires": {
         "json-stringify-safe": "^5.0.1",
         "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "fetch.js",
   "license": "ISC",
   "dependencies": {
-    "@financial-times/n-logger": "^8.0.0",
+    "@financial-times/n-logger": "^10.2.0",
     "http-errors": "^1.6.1",
     "node-fetch": "^2.0.0"
   },


### PR DESCRIPTION
n-logger v10.2.0 adds in the ability to switch to Heroku log drains
rather than sending logs to Splunk manually. In order to support this
feature we need to limit the version range to be v10.2.0 or above
otherwise the feature will be present inconsistently.

This is not a breaking change because the major versions of n-logger
between 8 and 10 have no impact on this package:

  - v9.0.0 of n-logger deprecates the SYSTEM_CODE environment variable
    (but then undeprecates it in v9.0.1)
  - v10.0.0 of n-logger only supports Node.js 14+ (no change for us)